### PR TITLE
Attempt to fix test code DeprecationWarning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: Test
       run: |
         poetry run pre-commit run --all-files
-        poetry run coverage run --module pytest
+        poetry run coverage run --module pytest -Werror
         poetry run coverage report
     - name: Build
       run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ markers =
     liveness: Rapid tests executed on a installation
     soak: Long tests executed at night
     unit: a test executed during build
+filterwarnings =
+    ignore:.*use of fork\(\) may lead to deadlocks in the child.*:DeprecationWarning:multiprocessing.popen_fork:67


### PR DESCRIPTION
- Add a pytest filter
- Caused by an internal Python DeprecationWaring relating to fork that may change (go) in Python 3.14