### PR TITLE
Add "instance_directory" property

### DIFF
--- a/tests/test_test_api_adapter.py
+++ b/tests/test_test_api_adapter.py
@@ -324,9 +324,20 @@ def test_get_running_workflow_step_with_prior_step():
 def test_create_instance():
     # Arrange
     utaa = UnitTestWorkflowAPIAdapter()
+    response = utaa.create_workflow(workflow_definition={"name": "blah"})
+    response = utaa.create_running_workflow(
+        user_id="dlister",
+        workflow_id=response["id"],
+        project_id=TEST_PROJECT_ID,
+        variables={},
+    )
+    response, _ = utaa.create_running_workflow_step(
+        running_workflow_id=response["id"], step="step-1"
+    )
+    rwfs_id = response["id"]
 
     # Act
-    response = utaa.create_instance(running_workflow_step_id="r-workflow-step-000")
+    response = utaa.create_instance(running_workflow_step_id=rwfs_id)
 
     # Assert
     assert "id" in response
@@ -335,14 +346,79 @@ def test_create_instance():
 def test_create_and_get_instance():
     # Arrange
     utaa = UnitTestWorkflowAPIAdapter()
-    response = utaa.create_instance(running_workflow_step_id="r-workflow-step-000")
+    response = utaa.create_workflow(workflow_definition={"name": "blah"})
+    response = utaa.create_running_workflow(
+        user_id="dlister",
+        workflow_id=response["id"],
+        project_id=TEST_PROJECT_ID,
+        variables={},
+    )
+    response, _ = utaa.create_running_workflow_step(
+        running_workflow_id=response["id"], step="step-1"
+    )
+    rwfs_id = response["id"]
+    response = utaa.create_instance(running_workflow_step_id=rwfs_id)
     instance_id = response["id"]
 
     # Act
     response, _ = utaa.get_instance(instance_id=instance_id)
 
     # Assert
-    assert response["running_workflow_step_id"] == "r-workflow-step-000"
+    assert response["running_workflow_step_id"] == rwfs_id
+
+
+def test_create_instance_and_get_step_instance_directory():
+    # Arrange
+    utaa = UnitTestWorkflowAPIAdapter()
+    response = utaa.create_workflow(workflow_definition={"name": "blah"})
+    response = utaa.create_running_workflow(
+        user_id="dlister",
+        workflow_id=response["id"],
+        project_id=TEST_PROJECT_ID,
+        variables={},
+    )
+    response, _ = utaa.create_running_workflow_step(
+        running_workflow_id=response["id"], step="step-1"
+    )
+    rwfs_id = response["id"]
+    response = utaa.create_instance(running_workflow_step_id=rwfs_id)
+    i_id = response["id"]
+
+    # Act
+    response, _ = utaa.get_running_workflow_step(running_workflow_step_id=rwfs_id)
+
+    # Assert
+    assert "instance_directory" in response
+    assert response["instance_directory"] == f".{i_id}"
+
+
+def test_create_instance_and_get_step_instance_directory_by_name():
+    # Arrange
+    utaa = UnitTestWorkflowAPIAdapter()
+    response = utaa.create_workflow(workflow_definition={"name": "blah"})
+    wf_id = response["id"]
+    response = utaa.create_running_workflow(
+        user_id="dlister",
+        workflow_id=wf_id,
+        project_id=TEST_PROJECT_ID,
+        variables={},
+    )
+    rwf_id = response["id"]
+    response, _ = utaa.create_running_workflow_step(
+        running_workflow_id=rwf_id, step="step-1"
+    )
+    rwfs_id = response["id"]
+    response = utaa.create_instance(running_workflow_step_id=rwfs_id)
+    i_id = response["id"]
+
+    # Act
+    response, _ = utaa.get_running_workflow_step_by_name(
+        running_workflow_id=rwf_id, name="step-1"
+    )
+
+    # Assert
+    assert "instance_directory" in response
+    assert response["instance_directory"] == f".{i_id}"
 
 
 def test_get_workflow_steps_driving_this_step_when_1st_step():

--- a/tests/wapi_adapter.py
+++ b/tests/wapi_adapter.py
@@ -377,6 +377,17 @@ class UnitTestWorkflowAPIAdapter(WorkflowAPIAdapter):
 
         with open(_INSTANCE_PICKLE_FILE, "wb") as pickle_file:
             Pickler(pickle_file).dump(instances)
+
+        # Use the instance ID as the step's instance-directory (prefixing with '.')
+        with open(_RUNNING_WORKFLOW_STEP_PICKLE_FILE, "rb") as pickle_file:
+            running_workflow_step = Unpickler(pickle_file).load()
+        assert running_workflow_step_id in running_workflow_step
+        running_workflow_step[running_workflow_step_id][
+            "instance_directory"
+        ] = f".{instance_id}"
+        with open(_RUNNING_WORKFLOW_STEP_PICKLE_FILE, "wb") as pickle_file:
+            Pickler(pickle_file).dump(running_workflow_step)
+
         UnitTestWorkflowAPIAdapter.lock.release()
 
         return {"id": instance_id}

--- a/tests/wapi_adapter.py
+++ b/tests/wapi_adapter.py
@@ -287,7 +287,7 @@ class UnitTestWorkflowAPIAdapter(WorkflowAPIAdapter):
             "steps": wf_response["steps"].copy(),
         }, 0
 
-    def get_instance(self, *, instance_id: str) -> dict[str, Any]:
+    def get_instance(self, *, instance_id: str) -> tuple[dict[str, Any], int]:
         UnitTestWorkflowAPIAdapter.lock.acquire()
         with open(_INSTANCE_PICKLE_FILE, "rb") as pickle_file:
             instances = Unpickler(pickle_file).load()

--- a/workflow/workflow_abc.py
+++ b/workflow/workflow_abc.py
@@ -334,12 +334,6 @@ class WorkflowAPIAdapter(ABC):
         #       }
         #     ]
         # }
-        #
-        # Additionally, if the step has started (an instance has been created)
-        # each entry on the array of steps will contain a "instance_directory" property
-        # that is the directory within the Project that's the step's working directory.
-        #
-        #       "instance_directory": ".instance-00000000-0000-0000-0000-00000000000a",
 
     @abstractmethod
     def get_instance(self, *, instance_id: str) -> tuple[dict[str, Any], int]:


### PR DESCRIPTION
- Steps now have an instance_directory property (when instances are created)
- Directory is exposed by get_running_workflow_step() and get_running_workflow_step_by_name()
- Directory is only available once an instance for the step has been created