### PR TITLE
ci: Create the GitHub Release automatically

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write  # Required to create the GitHub Release
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -52,3 +53,17 @@ jobs:
         poetry build --format wheel
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
+    # Create the corresponding GitHub Release.
+    # Releases used to be written by hand, which meant they could be (and were)
+    # forgotten - the package would be on PyPI with nothing on the releases page.
+    # The release is named after its tag and its notes are generated from the
+    # pull requests merged since the previous tag. Both can be edited afterwards
+    # if a more descriptive title is wanted.
+    # Any semver pre-release tag (i.e. one with a '-', like '3.0.0-rc.1') is
+    # marked as a pre-release so it does not become the repository's "Latest".
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        name: ${{ github.ref_name }}
+        generate_release_notes: true
+        prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
Pushing a tag built the wheel and published it to PyPI, but nothing in `.github/` created the corresponding **GitHub Release** — those were written by hand. That means they can be forgotten, which is exactly what happened for `3.0.0-rc.1`: the package went to PyPI with nothing on the releases page.

The publish workflow now creates the release as well.

## How it behaves

| | |
|---|---|
| Name | The tag (e.g. `3.0.0-rc.1`) |
| Notes | Generated from the pull requests merged since the previous release |
| Pre-release? | Yes for any tag containing `-` — i.e. any semver pre-release |

The pre-release flag matters: it stops `3.0.0-rc.1` becoming the repository's "Latest" release, mirroring how PyPI keeps a pre-release out of the `info.version` slot. Checked against every tag pattern this repo has used:

```
3.0.0-rc.1       -> prerelease=True
2.0.0-beta.8     -> prerelease=True
3.0.0            -> prerelease=False
1.5.2            -> prerelease=False
```

The job also needs `contents: write`, added alongside the existing `id-token: write`.

## Trade-off worth knowing

Past releases had hand-written descriptive titles — "Support for dirsGlob", "Combiners no longer get built-in variables" — and an automated step can't produce those. This names the release after its tag instead, on the basis that a release that exists and is plainly named beats one that was never created. Both the title and the notes stay editable afterwards.

If you'd rather keep the curated titles, the alternative is adding `draft: true`, so each tag produces a draft the maintainer titles and publishes. That still guarantees it is never silently skipped, but it keeps a manual step. Easy to switch — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
